### PR TITLE
Use proper delimiter for properties

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,10 +82,14 @@ async fn toggles(
                     }
                     // TODO: how are properties.k=v handled? what separator?
                     // This seems to be unspecified in the js client.
-                    k if k.starts_with("properties.") => {
+                    k if k.starts_with("properties[") => {
+                        // Get property from inside square brackets
+                        let mut propertyKey = k.split_at("properties[".len()).1.to_owned();
+                        // Pop last char "]"
+                        propertyKey.pop();
                         context
                             .properties
-                            .insert(k.split_at("properties".len()).1.to_owned(), v.to_string());
+                            .insert(propertyKey, v.to_string());
                     }
                     _ => {}
                 }


### PR DESCRIPTION
With this PR: https://github.com/unleash-hosted/unleash-proxy-client-js/pull/15 we will support sending properties in the search params. This changes how we get the properties from the search params using the format `properties[propertyKey]=propertyValue`